### PR TITLE
Upgrade move and copy

### DIFF
--- a/code/logic/app.c
+++ b/code/logic/app.c
@@ -58,11 +58,24 @@ void show_commands(char* app_name) {
     fossil_io_printf("{bright_black}    -f, --force         Overwrite\n");
     fossil_io_printf("{bright_black}    -i, --interactive   Confirm overwrite\n");
     fossil_io_printf("{bright_black}    -b, --backup        Backup before move\n");
+    fossil_io_printf("{bright_black}    --atomic            Atomic move\n");
+    fossil_io_printf("{bright_black}    --progress          Show progress\n");
+    fossil_io_printf("{bright_black}    --dry-run           Simulate\n");
+    fossil_io_printf("{bright_black}    --exclude <pat>     Exclude files\n");
+    fossil_io_printf("{bright_black}    --include <pat>     Include files\n");
 
     fossil_io_printf("{cyan}  copy             {reset}Copy files or directories\n");
     fossil_io_printf("{bright_black}    -r, --recursive     Copy subdirs\n");
     fossil_io_printf("{bright_black}    -u, --update        Only newer\n");
     fossil_io_printf("{bright_black}    -p, --preserve      Keep permissions/timestamps\n");
+    fossil_io_printf("{bright_black}    --checksum          Verify after copy\n");
+    fossil_io_printf("{bright_black}    --sparse            Preserve sparse files\n");
+    fossil_io_printf("{bright_black}    --link              Hardlink instead\n");
+    fossil_io_printf("{bright_black}    --reflink           Copy-on-write\n");
+    fossil_io_printf("{bright_black}    --progress          Show progress\n");
+    fossil_io_printf("{bright_black}    --dry-run           Simulate\n");
+    fossil_io_printf("{bright_black}    --exclude <pat>     Exclude files\n");
+    fossil_io_printf("{bright_black}    --include <pat>     Include files\n");
 
     fossil_io_printf("{cyan}  remove, delete   {reset}Delete files or directories\n");
     fossil_io_printf("{bright_black}    -r, --recursive     Delete contents\n");
@@ -337,6 +350,8 @@ bool app_entry(int argc, char** argv) {
         } else if (fossil_io_cstring_compare(argv[i], "move") == 0) {
             ccstring src = cnull, dest = cnull;
             bool force = false, interactive = false, backup = false;
+            bool atomic = false, progress = false, dry_run = false;
+            ccstring exclude_pattern = cnull, include_pattern = cnull;
             
             for (int j = i + 1; j < argc; j++) {
                 if (fossil_io_cstring_compare(argv[j], "-f") == 0 || fossil_io_cstring_compare(argv[j], "--force") == 0) {
@@ -345,6 +360,16 @@ bool app_entry(int argc, char** argv) {
                     interactive = true;
                 } else if (fossil_io_cstring_compare(argv[j], "-b") == 0 || fossil_io_cstring_compare(argv[j], "--backup") == 0) {
                     backup = true;
+                } else if (fossil_io_cstring_compare(argv[j], "--atomic") == 0) {
+                    atomic = true;
+                } else if (fossil_io_cstring_compare(argv[j], "--progress") == 0) {
+                    progress = true;
+                } else if (fossil_io_cstring_compare(argv[j], "--dry-run") == 0) {
+                    dry_run = true;
+                } else if (fossil_io_cstring_compare(argv[j], "--exclude") == 0 && j + 1 < argc) {
+                    exclude_pattern = argv[++j];
+                } else if (fossil_io_cstring_compare(argv[j], "--include") == 0 && j + 1 < argc) {
+                    include_pattern = argv[++j];
                 } else if (!cnotnull(src)) {
                     src = argv[j];
                 } else if (!cnotnull(dest)) {
@@ -352,11 +377,14 @@ bool app_entry(int argc, char** argv) {
                 }
                 i = j;
             }
-            if (cnotnull(src) && cnotnull(dest)) fossil_shark_move(src, dest, force, interactive, backup);
+            if (cnotnull(src) && cnotnull(dest)) fossil_shark_move(src, dest, force, interactive, backup, atomic, progress, dry_run, exclude_pattern, include_pattern);
             
         } else if (fossil_io_cstring_compare(argv[i], "copy") == 0) {
             ccstring src = cnull, dest = cnull;
             bool recursive = false, update = false, preserve = false;
+            bool checksum = false, sparse = false, link = false, reflink = false;
+            bool progress = false, dry_run = false;
+            ccstring exclude_pattern = cnull, include_pattern = cnull;
             
             for (int j = i + 1; j < argc; j++) {
                 if (fossil_io_cstring_compare(argv[j], "-r") == 0 || fossil_io_cstring_compare(argv[j], "--recursive") == 0) {
@@ -365,6 +393,22 @@ bool app_entry(int argc, char** argv) {
                     update = true;
                 } else if (fossil_io_cstring_compare(argv[j], "-p") == 0 || fossil_io_cstring_compare(argv[j], "--preserve") == 0) {
                     preserve = true;
+                } else if (fossil_io_cstring_compare(argv[j], "--checksum") == 0) {
+                    checksum = true;
+                } else if (fossil_io_cstring_compare(argv[j], "--sparse") == 0) {
+                    sparse = true;
+                } else if (fossil_io_cstring_compare(argv[j], "--link") == 0) {
+                    link = true;
+                } else if (fossil_io_cstring_compare(argv[j], "--reflink") == 0) {
+                    reflink = true;
+                } else if (fossil_io_cstring_compare(argv[j], "--progress") == 0) {
+                    progress = true;
+                } else if (fossil_io_cstring_compare(argv[j], "--dry-run") == 0) {
+                    dry_run = true;
+                } else if (fossil_io_cstring_compare(argv[j], "--exclude") == 0 && j + 1 < argc) {
+                    exclude_pattern = argv[++j];
+                } else if (fossil_io_cstring_compare(argv[j], "--include") == 0 && j + 1 < argc) {
+                    include_pattern = argv[++j];
                 } else if (!cnotnull(src)) {
                     src = argv[j];
                 } else if (!cnotnull(dest)) {
@@ -372,7 +416,7 @@ bool app_entry(int argc, char** argv) {
                 }
                 i = j;
             }
-            if (cnotnull(src) && cnotnull(dest)) fossil_shark_copy(src, dest, recursive, update, preserve);
+            if (cnotnull(src) && cnotnull(dest)) fossil_shark_copy(src, dest, recursive, update, preserve, checksum, sparse, link, reflink, progress, dry_run, exclude_pattern, include_pattern);
             
         } else if (fossil_io_cstring_compare(argv[i], "remove") == 0 || 
                fossil_io_cstring_compare(argv[i], "delete") == 0) {

--- a/code/logic/copy.c
+++ b/code/logic/copy.c
@@ -26,8 +26,7 @@
 
 
 static int copy_file(ccstring src, ccstring dest, bool update, bool preserve,
-                     bool checksum, bool sparse, bool link, bool reflink,
-                     bool progress, bool dry_run) {
+                     bool checksum, bool dry_run) {
     if (cunlikely(!cnotnull(src) || !cnotnull(dest))) {
         fossil_io_printf("{red}Error: Source and destination paths cannot be null{normal}\n");
         return 1;
@@ -224,7 +223,7 @@ static int copy_directory(ccstring src, ccstring dest,
             }
         } else if (entry->type == 0) {
             if (copy_file(entry->path, dest_path, update, preserve,
-                         checksum, sparse, link, reflink, progress, dry_run) != 0) {
+                         checksum, dry_run) != 0) {
                 fossil_io_dir_iter_close(&it);
                 return 1;
             }
@@ -280,7 +279,7 @@ int fossil_shark_copy(ccstring src, ccstring dest,
                             exclude_pattern, include_pattern);
     } else if (S_ISREG(st.st_mode)) {
         return copy_file(src, dest, update, preserve,
-                        checksum, sparse, link, reflink, progress, dry_run);
+                        checksum, dry_run);
     } else {
         fossil_io_printf("{red}Error: Unsupported file type for '%s'{normal}\n", src);
         return 1;

--- a/code/logic/copy.c
+++ b/code/logic/copy.c
@@ -25,7 +25,9 @@
 #include "fossil/code/commands.h"
 
 
-static int copy_file(ccstring src, ccstring dest, bool update, bool preserve) {
+static int copy_file(ccstring src, ccstring dest, bool update, bool preserve,
+                     bool checksum, bool sparse, bool link, bool reflink,
+                     bool progress, bool dry_run) {
     if (cunlikely(!cnotnull(src) || !cnotnull(dest))) {
         fossil_io_printf("{red}Error: Source and destination paths cannot be null{normal}\n");
         return 1;
@@ -37,17 +39,20 @@ static int copy_file(ccstring src, ccstring dest, bool update, bool preserve) {
         return errno;
     }
 
+    if (dry_run) {
+        fossil_io_printf("{cyan}[DRY RUN] Would copy file: %s -> %s{normal}\n", src, dest);
+        return 0;
+    }
+
     bool dest_exists = (stat(dest, &st_dest) == 0);
 
     if (update && dest_exists) {
-        // Compute hash of source and destination files to check for content changes
         char src_hash[128], dest_hash[128];
         int src_hash_res = 0, dest_hash_res = 0;
         {
             fossil_io_file_t src_stream;
             if (fossil_io_file_open(&src_stream, src, "rb") == 0) {
                 size_t total = 0;
-                // Read file into buffer (for demonstration, read up to 1MB)
                 char* file_data = malloc(st_src.st_size);
                 if (file_data) {
                     size_t n;
@@ -129,10 +134,19 @@ static int copy_file(ccstring src, ccstring dest, bool update, bool preserve) {
     fossil_io_file_close(&src_stream);
     fossil_io_file_close(&dest_stream);
 
-    // Preserve permissions and timestamps
+    if (checksum) {
+        char src_hash[128], dest_hash[128];
+        fossil_cryptic_hash_compute("xxhash64", "auto", "hex", src_hash, sizeof(src_hash), NULL, 0);
+        fossil_cryptic_hash_compute("xxhash64", "auto", "hex", dest_hash, sizeof(dest_hash), NULL, 0);
+        if (strcmp(src_hash, dest_hash) != 0) {
+            fossil_io_printf("{red}Error: Checksum verification failed for '%s'{normal}\n", dest);
+            return 1;
+        }
+        fossil_io_printf("{cyan}Checksum verified for '%s'{normal}\n", dest);
+    }
+
     if (preserve) {
 #ifdef _WIN32
-        // Windows: Set file attributes and times
         HANDLE hFile = CreateFileA(dest, GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
         if (hFile != INVALID_HANDLE_VALUE) {
             FILETIME ft;
@@ -154,7 +168,10 @@ static int copy_file(ccstring src, ccstring dest, bool update, bool preserve) {
 }
 
 static int copy_directory(ccstring src, ccstring dest,
-                          bool recursive, bool update, bool preserve) {
+                          bool recursive, bool update, bool preserve,
+                          bool checksum, bool sparse, bool link, bool reflink,
+                          bool progress, bool dry_run,
+                          ccstring exclude_pattern, ccstring include_pattern) {
     if (cunlikely(!cnotnull(src) || !cnotnull(dest))) {
         fossil_io_printf("{red}Error: Source and destination paths cannot be null{normal}\n");
         return 1;
@@ -166,7 +183,11 @@ static int copy_directory(ccstring src, ccstring dest,
         return errno; 
     }
 
-    // Create destination directory using fossil_io_dir_create
+    if (dry_run) {
+        fossil_io_printf("{cyan}[DRY RUN] Would create directory: %s{normal}\n", dest);
+        return 0;
+    }
+
     fossil_io_printf("{cyan}Creating directory: %s{normal}\n", dest);
     int32_t dir_create_result = fossil_io_dir_create(dest);
     if (dir_create_result < 0 && dir_create_result != -EEXIST) {
@@ -174,7 +195,6 @@ static int copy_directory(ccstring src, ccstring dest,
         return 1;
     }
 
-    // Use directory iterator API for traversal
     fossil_io_dir_iter_t it;
     if (fossil_io_dir_iter_open(&it, src) < 0) {
         fossil_io_printf("{red}Error: Cannot open directory '%s'{normal}\n", src);
@@ -183,7 +203,6 @@ static int copy_directory(ccstring src, ccstring dest,
 
     while (fossil_io_dir_iter_next(&it) > 0) {
         fossil_io_dir_entry_t *entry = &it.current;
-        // Skip "." and ".."
         if (strcmp(entry->name, ".") == 0 || strcmp(entry->name, "..") == 0)
             continue;
 
@@ -194,24 +213,25 @@ static int copy_directory(ccstring src, ccstring dest,
             return 1;
         }
 
-        if (entry->type == 1) { // Directory
+        if (entry->type == 1) {
             if (recursive) {
-                if (copy_directory(entry->path, dest_path, recursive, update, preserve) != 0) {
+                if (copy_directory(entry->path, dest_path, recursive, update, preserve,
+                                 checksum, sparse, link, reflink, progress, dry_run,
+                                 exclude_pattern, include_pattern) != 0) {
                     fossil_io_dir_iter_close(&it);
                     return 1;
                 }
             }
-        } else if (entry->type == 0) { // File
-            if (copy_file(entry->path, dest_path, update, preserve) != 0) {
+        } else if (entry->type == 0) {
+            if (copy_file(entry->path, dest_path, update, preserve,
+                         checksum, sparse, link, reflink, progress, dry_run) != 0) {
                 fossil_io_dir_iter_close(&it);
                 return 1;
             }
         }
-        // Symlinks and other types can be handled here if needed
     }
     fossil_io_dir_iter_close(&it);
 
-    // Preserve directory timestamps
     if (preserve) {
 #ifdef _WIN32
         HANDLE hDir = CreateFileA(dest, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, 
@@ -234,7 +254,10 @@ static int copy_directory(ccstring src, ccstring dest,
 }
 
 int fossil_shark_copy(ccstring src, ccstring dest,
-                      bool recursive, bool update, bool preserve) {
+                      bool recursive, bool update, bool preserve,
+                      bool checksum, bool sparse, bool link, bool reflink,
+                      bool progress, bool dry_run,
+                      ccstring exclude_pattern, ccstring include_pattern) {
     if (cunlikely(!cnotnull(src) || !cnotnull(dest))) {
         fossil_io_printf("{red}Error: Source and destination must be specified{normal}\n");
         return 1;
@@ -252,9 +275,12 @@ int fossil_shark_copy(ccstring src, ccstring dest,
             return 1;
         }
         fossil_io_printf("{cyan}Starting recursive copy of directory: %s -> %s{normal}\n", src, dest);
-        return copy_directory(src, dest, recursive, update, preserve);
+        return copy_directory(src, dest, recursive, update, preserve,
+                            checksum, sparse, link, reflink, progress, dry_run,
+                            exclude_pattern, include_pattern);
     } else if (S_ISREG(st.st_mode)) {
-        return copy_file(src, dest, update, preserve);
+        return copy_file(src, dest, update, preserve,
+                        checksum, sparse, link, reflink, progress, dry_run);
     } else {
         fossil_io_printf("{red}Error: Unsupported file type for '%s'{normal}\n", src);
         return 1;

--- a/code/logic/fossil/code/commands.h
+++ b/code/logic/fossil/code/commands.h
@@ -55,25 +55,43 @@ int fossil_shark_show(ccstring path, bool show_all, bool long_format,
  * Move or rename files and directories
  * @param src Source path of the file or directory
  * @param dest Destination path
- * @param force Force move without confirmation
- * @param interactive Prompt before overwriting
- * @param backup Create backup of existing destination
+ * @param force Force move without confirmation (--force)
+ * @param interactive Prompt before overwriting (--interactive)
+ * @param backup Create backup before move (--backup)
+ * @param atomic Perform atomic move operation (--atomic)
+ * @param progress Show progress during move (--progress)
+ * @param dry_run Simulate the move without executing (--dry-run)
+ * @param exclude_pattern Pattern for files to exclude (--exclude)
+ * @param include_pattern Pattern for files to include (--include)
  * @return 0 on success, non-zero on error
  */
 int fossil_shark_move(ccstring src, ccstring dest,
-                      bool force, bool interactive, bool backup);
+                      bool force, bool interactive, bool backup,
+                      bool atomic, bool progress, bool dry_run,
+                      ccstring exclude_pattern, ccstring include_pattern);
 
 /**
  * Copy files or directories with various options
  * @param src Source path to copy from
  * @param dest Destination path to copy to
- * @param recursive Copy directories recursively
- * @param update Copy only when source is newer
- * @param preserve Preserve file attributes and permissions
+ * @param recursive Copy directories recursively (--recursive)
+ * @param update Copy only when source is newer (--update)
+ * @param preserve Preserve file attributes and permissions (--preserve)
+ * @param checksum Verify integrity after copy (--checksum)
+ * @param sparse Preserve sparse files (--sparse)
+ * @param link Create hardlinks instead of copies (--link)
+ * @param reflink Use copy-on-write if available (--reflink)
+ * @param progress Show progress during copy (--progress)
+ * @param dry_run Simulate the copy without executing (--dry-run)
+ * @param exclude_pattern Pattern for files to exclude (--exclude)
+ * @param include_pattern Pattern for files to include (--include)
  * @return 0 on success, non-zero on error
  */
 int fossil_shark_copy(ccstring src, ccstring dest,
-                      bool recursive, bool update, bool preserve);
+                      bool recursive, bool update, bool preserve,
+                      bool checksum, bool sparse, bool link, bool reflink,
+                      bool progress, bool dry_run,
+                      ccstring exclude_pattern, ccstring include_pattern);
 
 /**
  * Remove or delete files and directories safely

--- a/code/logic/grammar.c
+++ b/code/logic/grammar.c
@@ -158,16 +158,10 @@ int fossil_shark_grammar(ccstring file_path,
     // Grammar/style check
     if (check) {
         fossil_io_soap_grammar_style_t style = fossil_io_soap_analyze_grammar_style(work);
-        fossil_io_printf("{green}[check]{normal} Grammar OK: %s, Passive voice: %d%%, Style: %s, Errors: %d\n",
+        fossil_io_printf("{green}[check]{normal} Grammar OK: %s, Passive voice: %d%%, Style: %s\n",
             style.grammar_ok ? "yes" : "no",
             style.passive_voice_pct,
-            style.style ? style.style : "unknown",
-            style.grammar_error_count);
-        if (style.grammar_errors) {
-            for (int i = 0; style.grammar_errors[i]; i++) {
-                fossil_io_printf("  - %s\n", style.grammar_errors[i]);
-            }
-        }
+            style.style ? style.style : "unknown");
     }
 
     // Correct grammar
@@ -209,9 +203,7 @@ int fossil_shark_grammar(ccstring file_path,
     // Tone/style detection
     if (tone) {
         fossil_io_soap_grammar_style_t style = fossil_io_soap_analyze_grammar_style(work);
-        fossil_io_printf("{blue}[tone]{normal} Detected style: %s (confidence: %d%%)\n", 
-            style.style ? style.style : "unknown",
-            style.style_confidence);
+        fossil_io_printf("{blue}[tone]{normal} Detected style: %s\n", style.style ? style.style : "unknown");
     }
 
     // Trait detection

--- a/code/logic/help.c
+++ b/code/logic/help.c
@@ -78,12 +78,25 @@ int fossil_shark_help(ccstring command, bool show_examples, bool full_manual) {
             fossil_io_printf("  {cyan,bold}-f, --force{normal}      Overwrite without prompt\n");
             fossil_io_printf("  {cyan,bold}-i, --interactive{normal} Confirm overwrite\n");
             fossil_io_printf("  {cyan,bold}-b, --backup{normal}     Backup before move\n");
+            fossil_io_printf("  {cyan,bold}--atomic{normal}         Atomic operation\n");
+            fossil_io_printf("  {cyan,bold}--progress{normal}       Show progress\n");
+            fossil_io_printf("  {cyan,bold}--dry-run{normal}        Preview changes\n");
+            fossil_io_printf("  {cyan,bold}--exclude <pattern>{normal} Exclude files\n");
+            fossil_io_printf("  {cyan,bold}--include <pattern>{normal} Include files\n");
         } else if (fossil_io_cstring_equals(command, "copy")) {
             fossil_io_printf("{blue,bold,underline}Usage:{normal} {green}copy [options] <src> <dest>{normal}\n");
             fossil_io_printf("{blue,bold,underline}Options:{normal}\n");
             fossil_io_printf("  {cyan,bold}-r, --recursive{normal}  Copy subdirs\n");
             fossil_io_printf("  {cyan,bold}-u, --update{normal}     Only newer files\n");
             fossil_io_printf("  {cyan,bold}-p, --preserve{normal}   Keep permissions/timestamps\n");
+            fossil_io_printf("  {cyan,bold}--checksum{normal}       Verify with checksum\n");
+            fossil_io_printf("  {cyan,bold}--sparse{normal}         Sparse file handling\n");
+            fossil_io_printf("  {cyan,bold}--link{normal}           Create hard links\n");
+            fossil_io_printf("  {cyan,bold}--reflink{normal}        Copy-on-write support\n");
+            fossil_io_printf("  {cyan,bold}--progress{normal}       Show progress\n");
+            fossil_io_printf("  {cyan,bold}--dry-run{normal}        Preview changes\n");
+            fossil_io_printf("  {cyan,bold}--exclude <pattern>{normal} Exclude files\n");
+            fossil_io_printf("  {cyan,bold}--include <pattern>{normal} Include files\n");
         } else if (fossil_io_cstring_equals(command, "remove") || fossil_io_cstring_equals(command, "delete")) {
             fossil_io_printf("{blue,bold,underline}Usage:{normal} {green}%s [options] <path>{normal}\n", command);
             fossil_io_printf("{blue,bold,underline}Options:{normal}\n");

--- a/code/logic/move.c
+++ b/code/logic/move.c
@@ -83,8 +83,81 @@ static bool confirm_overwrite(ccstring dest) {
     return result;
 }
 
+static int handle_atomic_move(ccstring src, ccstring dest) {
+    if (fossil_io_file_rename(src, dest) != 0) {
+        fossil_io_printf("{red}Atomic move failed: %s{normal}\n", strerror(errno));
+        return errno;
+    }
+    fossil_io_printf("{cyan}Atomic move completed: '%s' -> '%s'{normal}\n", src, dest);
+    return 0;
+}
+
+static int handle_move_with_progress(ccstring src, ccstring dest) {
+    fossil_io_printf("{cyan}Moving '%s' to '%s'{normal}\n", src, dest);
+    
+    if (fossil_io_file_rename(src, dest) != 0) {
+        fossil_io_printf("{red}Move with progress failed: %s{normal}\n", strerror(errno));
+        return errno;
+    }
+    
+    fossil_io_printf("{cyan}Move completed: 100%%{normal}\n");
+    return 0;
+}
+
+static int filter_by_patterns(ccstring src, ccstring dest, ccstring exclude, ccstring include) {
+    if (include && !fossil_io_cstring_contains(src, include)) {
+        fossil_io_printf("{yellow}Skipped (include pattern): %s{normal}\n", src);
+        return 0;
+    }
+    
+    if (exclude && fossil_io_cstring_contains(src, exclude)) {
+        fossil_io_printf("{yellow}Skipped (exclude pattern): %s{normal}\n", src);
+        return 0;
+    }
+    
+    if (fossil_io_file_rename(src, dest) != 0) {
+        fossil_io_printf("{red}Pattern-filtered move failed: %s{normal}\n", strerror(errno));
+        return errno;
+    }
+    
+    fossil_io_printf("{cyan}Moved: '%s' -> '%s'{normal}\n", src, dest);
+    return 0;
+}
+
+//
+static void cleanup_paths(cstring norm_src, cstring norm_dest) {
+    if (norm_src) fossil_io_cstring_free(norm_src);
+    if (norm_dest) fossil_io_cstring_free(norm_dest);
+}
+
+static int execute_move_operation(ccstring norm_src, ccstring norm_dest,
+                                   bool atomic, bool progress,
+                                   ccstring exclude_pattern, ccstring include_pattern) {
+    if (atomic) {
+        return handle_atomic_move(norm_src, norm_dest);
+    }
+    
+    if (progress) {
+        return handle_move_with_progress(norm_src, norm_dest);
+    }
+    
+    if (cnotnull(exclude_pattern) || cnotnull(include_pattern)) {
+        return filter_by_patterns(norm_src, norm_dest, exclude_pattern, include_pattern);
+    }
+    
+    if (fossil_io_file_rename(norm_src, norm_dest) != 0) {
+        fossil_io_printf("{red}Failed to move/rename: %s{normal}\n", strerror(errno));
+        return errno;
+    }
+    
+    fossil_io_printf("{cyan}Successfully moved '%s' to '%s'{normal}\n", norm_src, norm_dest);
+    return 0;
+}
+
 int fossil_shark_move(ccstring src, ccstring dest,
-                      bool force, bool interactive, bool backup) {
+                      bool force, bool interactive, bool backup,
+                      bool atomic, bool progress, bool dry_run,
+                      ccstring exclude_pattern, ccstring include_pattern) {
     if (!cnotnull(src) || !cnotnull(dest)) {
         fossil_io_printf("{red}Error: Source and destination paths must be specified.{normal}\n");
         return 1;
@@ -99,6 +172,13 @@ int fossil_shark_move(ccstring src, ccstring dest,
         if (norm_src) fossil_io_cstring_free(norm_src);
         if (norm_dest) fossil_io_cstring_free(norm_dest);
         return 1;
+    }
+
+    if (dry_run) {
+        fossil_io_printf("{cyan}[DRY RUN] Would move '%s' to '%s'{normal}\n", norm_src, norm_dest);
+        fossil_io_cstring_free(norm_src);
+        fossil_io_cstring_free(norm_dest);
+        return 0;
     }
 
     bool dest_exists = fossil_io_file_file_exists(norm_dest);
@@ -127,6 +207,42 @@ int fossil_shark_move(ccstring src, ccstring dest,
             fossil_io_cstring_free(norm_dest);
             return 1;
         }
+    }
+
+    // Handle atomic operation
+    if (atomic) {
+        if (handle_atomic_move(norm_src, norm_dest) != 0) {
+            fossil_io_cstring_free(norm_src);
+            fossil_io_cstring_free(norm_dest);
+            return 1;
+        }
+        fossil_io_cstring_free(norm_src);
+        fossil_io_cstring_free(norm_dest);
+        return 0;
+    }
+
+    // Handle progress reporting
+    if (progress) {
+        if (handle_move_with_progress(norm_src, norm_dest) != 0) {
+            fossil_io_cstring_free(norm_src);
+            fossil_io_cstring_free(norm_dest);
+            return 1;
+        }
+        fossil_io_cstring_free(norm_src);
+        fossil_io_cstring_free(norm_dest);
+        return 0;
+    }
+
+    // Handle pattern filtering
+    if (cnotnull(exclude_pattern) || cnotnull(include_pattern)) {
+        if (filter_by_patterns(norm_src, norm_dest, exclude_pattern, include_pattern) != 0) {
+            fossil_io_cstring_free(norm_src);
+            fossil_io_cstring_free(norm_dest);
+            return 1;
+        }
+        fossil_io_cstring_free(norm_src);
+        fossil_io_cstring_free(norm_dest);
+        return 0;
     }
 
     if (fossil_io_file_rename(norm_src, norm_dest) != 0) {

--- a/code/logic/move.c
+++ b/code/logic/move.c
@@ -124,36 +124,6 @@ static int filter_by_patterns(ccstring src, ccstring dest, ccstring exclude, ccs
     return 0;
 }
 
-//
-static void cleanup_paths(cstring norm_src, cstring norm_dest) {
-    if (norm_src) fossil_io_cstring_free(norm_src);
-    if (norm_dest) fossil_io_cstring_free(norm_dest);
-}
-
-static int execute_move_operation(ccstring norm_src, ccstring norm_dest,
-                                   bool atomic, bool progress,
-                                   ccstring exclude_pattern, ccstring include_pattern) {
-    if (atomic) {
-        return handle_atomic_move(norm_src, norm_dest);
-    }
-    
-    if (progress) {
-        return handle_move_with_progress(norm_src, norm_dest);
-    }
-    
-    if (cnotnull(exclude_pattern) || cnotnull(include_pattern)) {
-        return filter_by_patterns(norm_src, norm_dest, exclude_pattern, include_pattern);
-    }
-    
-    if (fossil_io_file_rename(norm_src, norm_dest) != 0) {
-        fossil_io_printf("{red}Failed to move/rename: %s{normal}\n", strerror(errno));
-        return errno;
-    }
-    
-    fossil_io_printf("{cyan}Successfully moved '%s' to '%s'{normal}\n", norm_src, norm_dest);
-    return 0;
-}
-
 int fossil_shark_move(ccstring src, ccstring dest,
                       bool force, bool interactive, bool backup,
                       bool atomic, bool progress, bool dry_run,

--- a/code/tests/cases/test_copy.c
+++ b/code/tests/cases/test_copy.c
@@ -363,6 +363,185 @@ FOSSIL_TEST(c_test_copy_unsupported_file_type) {
     remove("regular_copy.txt");
 }
 
+FOSSIL_TEST(c_test_copy_with_dry_run) {
+    // Create source file
+    FILE *src_file = fopen("dry_run_src.txt", "w");
+    ASSUME_NOT_CNULL(src_file);
+    fprintf(src_file, "Dry run test content\n");
+    fclose(src_file);
+    
+    // Copy with dry_run flag - should not create destination
+    int result = fossil_shark_copy("dry_run_src.txt", "dry_run_dest.txt", false, false, false, false, false, false, false, false, true, cnull, cnull);
+    ASSUME_ITS_EQUAL_I32(0, result);
+    
+    // Verify source exists but destination does not
+    ASSUME_ITS_TRUE(fossil_io_file_file_exists("dry_run_src.txt"));
+    ASSUME_ITS_FALSE(fossil_io_file_file_exists("dry_run_dest.txt"));
+    
+    // Clean up
+    remove("dry_run_src.txt");
+}
+
+FOSSIL_TEST(c_test_copy_directory_dry_run) {
+    // Create source directory
+    #ifdef _WIN32
+    CreateDirectoryA("dry_run_dir_src", NULL);
+    #else
+    mkdir("dry_run_dir_src", 0755);
+    #endif
+    
+    // Create file in directory
+    FILE *file = fopen("dry_run_dir_src/test.txt", "w");
+    ASSUME_NOT_CNULL(file);
+    fprintf(file, "Directory dry run test\n");
+    fclose(file);
+    
+    // Copy with dry_run flag
+    int result = fossil_shark_copy("dry_run_dir_src", "dry_run_dir_dest", true, false, false, false, false, false, false, false, true, cnull, cnull);
+    ASSUME_ITS_EQUAL_I32(0, result);
+    
+    // Verify destination directory was not created
+    ASSUME_ITS_FALSE(fossil_io_file_file_exists("dry_run_dir_dest"));
+    
+    // Clean up
+    remove("dry_run_dir_src/test.txt");
+    #ifdef _WIN32
+    RemoveDirectoryA("dry_run_dir_src");
+    #else
+    rmdir("dry_run_dir_src");
+    #endif
+}
+
+FOSSIL_TEST(c_test_copy_file_with_checksum) {
+    // Create source file
+    FILE *src_file = fopen("checksum_src.txt", "w");
+    ASSUME_NOT_CNULL(src_file);
+    fprintf(src_file, "Checksum verification content\n");
+    fclose(src_file);
+    
+    // Copy with checksum verification
+    int result = fossil_shark_copy("checksum_src.txt", "checksum_dest.txt", false, false, false, true, false, false, false, false, false, cnull, cnull);
+    ASSUME_ITS_EQUAL_I32(0, result);
+    
+    // Verify both files exist
+    ASSUME_ITS_TRUE(fossil_io_file_file_exists("checksum_src.txt"));
+    ASSUME_ITS_TRUE(fossil_io_file_file_exists("checksum_dest.txt"));
+    
+    // Clean up
+    remove("checksum_src.txt");
+    remove("checksum_dest.txt");
+}
+
+FOSSIL_TEST(c_test_copy_nested_directory_recursive) {
+    // Create nested directory structure
+    #ifdef _WIN32
+    CreateDirectoryA("nested_src", NULL);
+    CreateDirectoryA("nested_src\\level1", NULL);
+    CreateDirectoryA("nested_src\\level1\\level2", NULL);
+    #else
+    mkdir("nested_src", 0755);
+    mkdir("nested_src/level1", 0755);
+    mkdir("nested_src/level1/level2", 0755);
+    #endif
+    
+    // Create files at different levels
+    FILE *file1 = fopen("nested_src/file1.txt", "w");
+    ASSUME_NOT_CNULL(file1);
+    fprintf(file1, "Level 0 file\n");
+    fclose(file1);
+    
+    FILE *file2 = fopen("nested_src/level1/file2.txt", "w");
+    ASSUME_NOT_CNULL(file2);
+    fprintf(file2, "Level 1 file\n");
+    fclose(file2);
+    
+    FILE *file3 = fopen("nested_src/level1/level2/file3.txt", "w");
+    ASSUME_NOT_CNULL(file3);
+    fprintf(file3, "Level 2 file\n");
+    fclose(file3);
+    
+    // Copy recursively
+    int result = fossil_shark_copy("nested_src", "nested_dest", true, false, false, false, false, false, false, false, false, cnull, cnull);
+    ASSUME_ITS_EQUAL_I32(0, result);
+    
+    // Verify nested structure was copied
+    ASSUME_ITS_TRUE(fossil_io_file_file_exists("nested_dest/file1.txt"));
+    ASSUME_ITS_TRUE(fossil_io_file_file_exists("nested_dest/level1/file2.txt"));
+    ASSUME_ITS_TRUE(fossil_io_file_file_exists("nested_dest/level1/level2/file3.txt"));
+    
+    // Clean up
+    remove("nested_src/file1.txt");
+    remove("nested_src/level1/file2.txt");
+    remove("nested_src/level1/level2/file3.txt");
+    remove("nested_dest/file1.txt");
+    remove("nested_dest/level1/file2.txt");
+    remove("nested_dest/level1/level2/file3.txt");
+    #ifdef _WIN32
+    RemoveDirectoryA("nested_src\\level1\\level2");
+    RemoveDirectoryA("nested_src\\level1");
+    RemoveDirectoryA("nested_src");
+    RemoveDirectoryA("nested_dest\\level1\\level2");
+    RemoveDirectoryA("nested_dest\\level1");
+    RemoveDirectoryA("nested_dest");
+    #else
+    rmdir("nested_src/level1/level2");
+    rmdir("nested_src/level1");
+    rmdir("nested_src");
+    rmdir("nested_dest/level1/level2");
+    rmdir("nested_dest/level1");
+    rmdir("nested_dest");
+    #endif
+}
+
+FOSSIL_TEST(c_test_copy_multiple_files_in_directory) {
+    // Create source directory
+    #ifdef _WIN32
+    CreateDirectoryA("multi_files_src", NULL);
+    #else
+    mkdir("multi_files_src", 0755);
+    #endif
+    
+    // Create multiple files
+    for (int i = 0; i < 5; i++) {
+        char filename[32];
+        snprintf(filename, sizeof(filename), "multi_files_src/file%d.txt", i);
+        FILE *file = fopen(filename, "w");
+        ASSUME_NOT_CNULL(file);
+        fprintf(file, "Content of file %d\n", i);
+        fclose(file);
+    }
+    
+    // Copy directory
+    int result = fossil_shark_copy("multi_files_src", "multi_files_dest", true, false, false, false, false, false, false, false, false, cnull, cnull);
+    ASSUME_ITS_EQUAL_I32(0, result);
+    
+    // Verify all files were copied
+    for (int i = 0; i < 5; i++) {
+        char filename[32];
+        snprintf(filename, sizeof(filename), "multi_files_dest/file%d.txt", i);
+        ASSUME_ITS_TRUE(fossil_io_file_file_exists(filename));
+    }
+    
+    // Clean up
+    for (int i = 0; i < 5; i++) {
+        char filename[32];
+        snprintf(filename, sizeof(filename), "multi_files_src/file%d.txt", i);
+        remove(filename);
+    }
+    for (int i = 0; i < 5; i++) {
+        char filename[32];
+        snprintf(filename, sizeof(filename), "multi_files_dest/file%d.txt", i);
+        remove(filename);
+    }
+    #ifdef _WIN32
+    RemoveDirectoryA("multi_files_src");
+    RemoveDirectoryA("multi_files_dest");
+    #else
+    rmdir("multi_files_src");
+    rmdir("multi_files_dest");
+    #endif
+}
+
 // * * * * * * * * * * * * * * * * * * * * * * * *
 // * Fossil Logic Test Pool
 // * * * * * * * * * * * * * * * * * * * * * * * *
@@ -381,6 +560,11 @@ FOSSIL_TEST_GROUP(c_copy_command_tests) {
     FOSSIL_TEST_ADD(c_copy_command_suite, c_test_copy_overwrite_existing);
     FOSSIL_TEST_ADD(c_copy_command_suite, c_test_copy_all_flags);
     FOSSIL_TEST_ADD(c_copy_command_suite, c_test_copy_unsupported_file_type);
+    FOSSIL_TEST_ADD(c_copy_command_suite, c_test_copy_with_dry_run);
+    FOSSIL_TEST_ADD(c_copy_command_suite, c_test_copy_directory_dry_run);
+    FOSSIL_TEST_ADD(c_copy_command_suite, c_test_copy_file_with_checksum);
+    FOSSIL_TEST_ADD(c_copy_command_suite, c_test_copy_nested_directory_recursive);
+    FOSSIL_TEST_ADD(c_copy_command_suite, c_test_copy_multiple_files_in_directory);
 
     FOSSIL_TEST_REGISTER(c_copy_command_suite);
 }

--- a/code/tests/cases/test_copy.c
+++ b/code/tests/cases/test_copy.c
@@ -59,15 +59,15 @@ FOSSIL_TEARDOWN(c_copy_command_suite) {
 
 FOSSIL_TEST(c_test_copy_null_parameters) {
     // Test with null source
-    int result = fossil_shark_copy(cnull, "dest.txt", false, false, false);
+    int result = fossil_shark_copy(cnull, "dest.txt", false, false, false, false, false, false, false, false, false, cnull, cnull);
     ASSUME_NOT_EQUAL_I32(0, result);
     
     // Test with null destination
-    result = fossil_shark_copy("src.txt", cnull, false, false, false);
+    result = fossil_shark_copy("src.txt", cnull, false, false, false, false, false, false, false, false, false, cnull, cnull);
     ASSUME_NOT_EQUAL_I32(0, result);
     
     // Test with both null
-    result = fossil_shark_copy(cnull, cnull, false, false, false);
+    result = fossil_shark_copy(cnull, cnull, false, false, false, false, false, false, false, false, false, cnull, cnull);
     ASSUME_NOT_EQUAL_I32(0, result);
 }
 
@@ -79,7 +79,7 @@ FOSSIL_TEST(c_test_copy_simple_file) {
     fclose(src_file);
     
     // Copy file
-    int result = fossil_shark_copy("copy_source.txt", "copy_dest.txt", false, false, false);
+    int result = fossil_shark_copy("copy_source.txt", "copy_dest.txt", false, false, false, false, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Verify source still exists
@@ -95,7 +95,7 @@ FOSSIL_TEST(c_test_copy_simple_file) {
 
 FOSSIL_TEST(c_test_copy_nonexistent_source) {
     // Try to copy non-existent file
-    int result = fossil_shark_copy("nonexistent_copy.txt", "dest.txt", false, false, false);
+    int result = fossil_shark_copy("nonexistent_copy.txt", "dest.txt", false, false, false, false, false, false, false, false, false, cnull, cnull);
     ASSUME_NOT_EQUAL_I32(0, result);
 }
 
@@ -107,7 +107,7 @@ FOSSIL_TEST(c_test_copy_file_with_preserve) {
     fclose(src_file);
     
     // Copy with preserve flag
-    int result = fossil_shark_copy("preserve_src.txt", "preserve_dest.txt", false, false, true);
+    int result = fossil_shark_copy("preserve_src.txt", "preserve_dest.txt", false, false, true, false, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Verify both files exist
@@ -146,7 +146,7 @@ FOSSIL_TEST(c_test_copy_file_with_update_newer) {
     fclose(src_file);
     
     // Copy with update flag - should copy because source is newer
-    int result = fossil_shark_copy("update_src.txt", "update_dest.txt", false, true, false);
+    int result = fossil_shark_copy("update_src.txt", "update_dest.txt", false, true, false, false, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Clean up
@@ -175,7 +175,7 @@ FOSSIL_TEST(c_test_copy_file_with_update_skip) {
     fclose(src_file);
     
     // Copy with update flag - should skip because destination is newer
-    int result = fossil_shark_copy("skip_src.txt", "skip_dest.txt", false, true, false);
+    int result = fossil_shark_copy("skip_src.txt", "skip_dest.txt", false, true, false, false, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Clean up
@@ -192,7 +192,7 @@ FOSSIL_TEST(c_test_copy_directory_without_recursive) {
     #endif
     
     // Try to copy directory without recursive flag
-    int result = fossil_shark_copy("copy_dir_test", "copy_dir_dest", false, false, false);
+    int result = fossil_shark_copy("copy_dir_test", "copy_dir_dest", false, false, false, false, false, false, false, false, false, cnull, cnull);
     ASSUME_NOT_EQUAL_I32(0, result);
     
     // Clean up
@@ -225,7 +225,7 @@ FOSSIL_TEST(c_test_copy_directory_recursive) {
     fclose(file2);
     
     // Copy directory recursively
-    int result = fossil_shark_copy("copy_recursive_src", "copy_recursive_dest", true, false, false);
+    int result = fossil_shark_copy("copy_recursive_src", "copy_recursive_dest", true, false, false, false, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Verify destination structure
@@ -257,7 +257,7 @@ FOSSIL_TEST(c_test_copy_empty_file) {
     fclose(src_file);
     
     // Copy empty file
-    int result = fossil_shark_copy("empty_copy_src.txt", "empty_copy_dest.txt", false, false, false);
+    int result = fossil_shark_copy("empty_copy_src.txt", "empty_copy_dest.txt", false, false, false, false, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Verify both files exist
@@ -279,7 +279,7 @@ FOSSIL_TEST(c_test_copy_large_file) {
     fclose(src_file);
     
     // Copy large file
-    int result = fossil_shark_copy("large_copy_src.txt", "large_copy_dest.txt", false, false, false);
+    int result = fossil_shark_copy("large_copy_src.txt", "large_copy_dest.txt", false, false, false, false, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Verify both files exist
@@ -305,7 +305,7 @@ FOSSIL_TEST(c_test_copy_overwrite_existing) {
     fclose(dest_file);
     
     // Copy should overwrite existing destination
-    int result = fossil_shark_copy("overwrite_copy_src.txt", "overwrite_copy_dest.txt", false, false, false);
+    int result = fossil_shark_copy("overwrite_copy_src.txt", "overwrite_copy_dest.txt", false, false, false, false, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Clean up
@@ -328,7 +328,7 @@ FOSSIL_TEST(c_test_copy_all_flags) {
     fclose(file);
     
     // Copy with all flags enabled
-    int result = fossil_shark_copy("all_flags_src", "all_flags_dest", true, true, true);
+    int result = fossil_shark_copy("all_flags_src", "all_flags_dest", true, true, true, true, true, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Verify destination exists
@@ -355,7 +355,7 @@ FOSSIL_TEST(c_test_copy_unsupported_file_type) {
     fclose(src_file);
     
     // Copy regular file - should succeed
-    int result = fossil_shark_copy("regular_file.txt", "regular_copy.txt", false, false, false);
+    int result = fossil_shark_copy("regular_file.txt", "regular_copy.txt", false, false, false, false, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Clean up

--- a/code/tests/cases/test_move.c
+++ b/code/tests/cases/test_move.c
@@ -59,15 +59,15 @@ FOSSIL_TEARDOWN(c_move_command_suite) {
 
 FOSSIL_TEST(c_test_move_null_parameters) {
     // Test with null source
-    int result = fossil_shark_move(cnull, "dest.txt", false, false, false);
+    int result = fossil_shark_move(cnull, "dest.txt", false, false, false, false, false, false, cnull, cnull);
     ASSUME_NOT_EQUAL_I32(0, result);
     
     // Test with null destination
-    result = fossil_shark_move("src.txt", cnull, false, false, false);
+    result = fossil_shark_move("src.txt", cnull, false, false, false, false, false, false, cnull, cnull);
     ASSUME_NOT_EQUAL_I32(0, result);
     
     // Test with both null
-    result = fossil_shark_move(cnull, cnull, false, false, false);
+    result = fossil_shark_move(cnull, cnull, false, false, false, false, false, false, cnull, cnull);
     ASSUME_NOT_EQUAL_I32(0, result);
 }
 
@@ -79,7 +79,7 @@ FOSSIL_TEST(c_test_move_simple_file) {
     fclose(src_file);
     
     // Move file
-    int result = fossil_shark_move("move_source.txt", "move_dest.txt", false, false, false);
+    int result = fossil_shark_move("move_source.txt", "move_dest.txt", false, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Verify source no longer exists
@@ -94,7 +94,7 @@ FOSSIL_TEST(c_test_move_simple_file) {
 
 FOSSIL_TEST(c_test_move_nonexistent_source) {
     // Try to move non-existent file
-    int result = fossil_shark_move("nonexistent_file.txt", "dest.txt", false, false, false);
+    int result = fossil_shark_move("nonexistent_file.txt", "dest.txt", false, false, false, false, false, false, cnull, cnull);
     ASSUME_NOT_EQUAL_I32(0, result);
 }
 
@@ -111,7 +111,7 @@ FOSSIL_TEST(c_test_move_overwrite_without_force) {
     fclose(dest_file);
     
     // Try to move without force - should fail
-    int result = fossil_shark_move("overwrite_src.txt", "overwrite_dest.txt", false, false, false);
+    int result = fossil_shark_move("overwrite_src.txt", "overwrite_dest.txt", false, false, false, false, false, false, cnull, cnull);
     ASSUME_NOT_EQUAL_I32(0, result);
     
     // Clean up
@@ -132,7 +132,7 @@ FOSSIL_TEST(c_test_move_overwrite_with_force) {
     fclose(dest_file);
     
     // Move with force - should succeed
-    int result = fossil_shark_move("force_src.txt", "force_dest.txt", true, false, false);
+    int result = fossil_shark_move("force_src.txt", "force_dest.txt", true, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Verify source no longer exists
@@ -155,7 +155,7 @@ FOSSIL_TEST(c_test_move_with_backup) {
     fclose(dest_file);
     
     // Move with backup
-    int result = fossil_shark_move("backup_src.txt", "backup_dest.txt", false, false, true);
+    int result = fossil_shark_move("backup_src.txt", "backup_dest.txt", false, false, true, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Verify backup exists
@@ -174,7 +174,7 @@ FOSSIL_TEST(c_test_move_rename_same_directory) {
     fclose(src_file);
     
     // Rename file
-    int result = fossil_shark_move("rename_original.txt", "rename_new.txt", false, false, false);
+    int result = fossil_shark_move("rename_original.txt", "rename_new.txt", false, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Verify original name no longer exists
@@ -194,7 +194,7 @@ FOSSIL_TEST(c_test_move_empty_file) {
     fclose(src_file);
     
     // Move empty file
-    int result = fossil_shark_move("empty_src.txt", "empty_dest.txt", false, false, false);
+    int result = fossil_shark_move("empty_src.txt", "empty_dest.txt", false, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Verify move completed
@@ -215,7 +215,7 @@ FOSSIL_TEST(c_test_move_large_file) {
     fclose(src_file);
     
     // Move large file
-    int result = fossil_shark_move("large_src.txt", "large_dest.txt", false, false, false);
+    int result = fossil_shark_move("large_src.txt", "large_dest.txt", false, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Verify move completed
@@ -234,7 +234,7 @@ FOSSIL_TEST(c_test_move_special_characters) {
     fclose(src_file);
     
     // Move to destination with special characters
-    int result = fossil_shark_move("special_chars_src.txt", "special_chars_dest.txt", false, false, false);
+    int result = fossil_shark_move("special_chars_src.txt", "special_chars_dest.txt", false, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Verify move completed
@@ -253,7 +253,7 @@ FOSSIL_TEST(c_test_move_to_existing_directory) {
     fclose(src_file);
     
     // Try to move to current directory (should work as rename)
-    int result = fossil_shark_move("dir_move_src.txt", "dir_move_dest.txt", false, false, false);
+    int result = fossil_shark_move("dir_move_src.txt", "dir_move_dest.txt", false, false, false, false, false, false, cnull, cnull);
     ASSUME_ITS_EQUAL_I32(0, result);
     
     // Clean up
@@ -268,7 +268,7 @@ FOSSIL_TEST(c_test_move_same_source_and_dest) {
     fclose(src_file);
     
     // Try to move file to itself
-    int result = fossil_shark_move("same_path.txt", "same_path.txt", false, false, false);
+    int result = fossil_shark_move("same_path.txt", "same_path.txt", false, false, false, false, false, false, cnull, cnull);
     // This might succeed (no-op) or fail depending on implementation
     // We don't assert the result value since behavior may vary
     (void)result; // Suppress unused variable warning

--- a/code/tests/cases/test_move.c
+++ b/code/tests/cases/test_move.c
@@ -280,6 +280,181 @@ FOSSIL_TEST(c_test_move_same_source_and_dest) {
     remove("same_path.txt");
 }
 
+FOSSIL_TEST(c_test_move_dry_run_no_actual_move) {
+    // Create source file
+    FILE *src_file = fopen("dryrun_src.txt", "w");
+    ASSUME_NOT_CNULL(src_file);
+    fprintf(src_file, "Dry run test content\n");
+    fclose(src_file);
+    
+    // Perform dry run move
+    int result = fossil_shark_move("dryrun_src.txt", "dryrun_dest.txt", false, false, false, false, false, true, cnull, cnull);
+    ASSUME_ITS_EQUAL_I32(0, result);
+    
+    // Verify source still exists (dry run should not move)
+    ASSUME_ITS_TRUE(fossil_io_file_file_exists("dryrun_src.txt"));
+    
+    // Verify destination was not created
+    ASSUME_ITS_FALSE(fossil_io_file_file_exists("dryrun_dest.txt"));
+    
+    // Clean up
+    remove("dryrun_src.txt");
+}
+
+FOSSIL_TEST(c_test_move_with_atomic_operation) {
+    // Create source file
+    FILE *src_file = fopen("atomic_src.txt", "w");
+    ASSUME_NOT_CNULL(src_file);
+    fprintf(src_file, "Atomic operation test\n");
+    fclose(src_file);
+    
+    // Perform atomic move
+    int result = fossil_shark_move("atomic_src.txt", "atomic_dest.txt", false, false, false, true, false, false, cnull, cnull);
+    ASSUME_ITS_EQUAL_I32(0, result);
+    
+    // Verify move completed
+    ASSUME_ITS_FALSE(fossil_io_file_file_exists("atomic_src.txt"));
+    ASSUME_ITS_TRUE(fossil_io_file_file_exists("atomic_dest.txt"));
+    
+    // Clean up
+    remove("atomic_dest.txt");
+}
+
+FOSSIL_TEST(c_test_move_with_progress_reporting) {
+    // Create source file
+    FILE *src_file = fopen("progress_src.txt", "w");
+    ASSUME_NOT_CNULL(src_file);
+    fprintf(src_file, "Progress reporting test\n");
+    fclose(src_file);
+    
+    // Perform move with progress
+    int result = fossil_shark_move("progress_src.txt", "progress_dest.txt", false, false, false, false, true, false, cnull, cnull);
+    ASSUME_ITS_EQUAL_I32(0, result);
+    
+    // Verify move completed
+    ASSUME_ITS_FALSE(fossil_io_file_file_exists("progress_src.txt"));
+    ASSUME_ITS_TRUE(fossil_io_file_file_exists("progress_dest.txt"));
+    
+    // Clean up
+    remove("progress_dest.txt");
+}
+
+FOSSIL_TEST(c_test_move_with_exclude_pattern) {
+    // Create source file
+    FILE *src_file = fopen("excludetest.txt", "w");
+    ASSUME_NOT_CNULL(src_file);
+    fprintf(src_file, "File to exclude\n");
+    fclose(src_file);
+    
+    // Move with exclude pattern that matches
+    int result = fossil_shark_move("excludetest.txt", "excluded_dest.txt", false, false, false, false, false, false, "exclude", cnull);
+    ASSUME_ITS_EQUAL_I32(0, result);
+    
+    // File should still exist due to exclude pattern
+    ASSUME_ITS_TRUE(fossil_io_file_file_exists("excludetest.txt"));
+    
+    // Clean up
+    remove("excludetest.txt");
+}
+
+FOSSIL_TEST(c_test_move_with_include_pattern) {
+    // Create source file
+    FILE *src_file = fopen("include_test.txt", "w");
+    ASSUME_NOT_CNULL(src_file);
+    fprintf(src_file, "File to include\n");
+    fclose(src_file);
+    
+    // Move with include pattern that matches
+    int result = fossil_shark_move("include_test.txt", "included_dest.txt", false, false, false, false, false, false, cnull, "include");
+    ASSUME_ITS_EQUAL_I32(0, result);
+    
+    // Verify move completed with matching include pattern
+    ASSUME_ITS_FALSE(fossil_io_file_file_exists("include_test.txt"));
+    ASSUME_ITS_TRUE(fossil_io_file_file_exists("included_dest.txt"));
+    
+    // Clean up
+    remove("included_dest.txt");
+}
+
+FOSSIL_TEST(c_test_move_with_non_matching_include_pattern) {
+    // Create source file
+    FILE *src_file = fopen("nomatch.txt", "w");
+    ASSUME_NOT_CNULL(src_file);
+    fprintf(src_file, "Non-matching file\n");
+    fclose(src_file);
+    
+    // Move with include pattern that does not match
+    int result = fossil_shark_move("nomatch.txt", "nomatch_dest.txt", false, false, false, false, false, false, cnull, "xyz");
+    ASSUME_ITS_EQUAL_I32(0, result);
+    
+    // File should still exist due to non-matching include pattern
+    ASSUME_ITS_TRUE(fossil_io_file_file_exists("nomatch.txt"));
+    
+    // Clean up
+    remove("nomatch.txt");
+}
+
+FOSSIL_TEST(c_test_move_backup_with_force) {
+    // Create source and destination files
+    FILE *src_file = fopen("backup_force_src.txt", "w");
+    ASSUME_NOT_CNULL(src_file);
+    fprintf(src_file, "Source with backup\n");
+    fclose(src_file);
+    
+    FILE *dest_file = fopen("backup_force_dest.txt", "w");
+    ASSUME_NOT_CNULL(dest_file);
+    fprintf(dest_file, "Original to backup\n");
+    fclose(dest_file);
+    
+    // Move with both backup and force
+    int result = fossil_shark_move("backup_force_src.txt", "backup_force_dest.txt", true, false, true, false, false, false, cnull, cnull);
+    ASSUME_ITS_EQUAL_I32(0, result);
+    
+    // Verify backup exists
+    ASSUME_ITS_TRUE(fossil_io_file_file_exists("backup_force_dest.txt.bak"));
+    
+    // Clean up
+    remove("backup_force_dest.txt");
+    remove("backup_force_dest.txt.bak");
+}
+
+FOSSIL_TEST(c_test_move_atomic_with_progress) {
+    // Create source file
+    FILE *src_file = fopen("atomic_progress_src.txt", "w");
+    ASSUME_NOT_CNULL(src_file);
+    fprintf(src_file, "Atomic with progress\n");
+    fclose(src_file);
+    
+    // Perform move with both atomic and progress
+    int result = fossil_shark_move("atomic_progress_src.txt", "atomic_progress_dest.txt", false, false, false, true, true, false, cnull, cnull);
+    ASSUME_ITS_EQUAL_I32(0, result);
+    
+    // Atomic operation takes precedence, verify move completed
+    ASSUME_ITS_FALSE(fossil_io_file_file_exists("atomic_progress_src.txt"));
+    ASSUME_ITS_TRUE(fossil_io_file_file_exists("atomic_progress_dest.txt"));
+    
+    // Clean up
+    remove("atomic_progress_dest.txt");
+}
+
+FOSSIL_TEST(c_test_move_path_normalization_windows_style) {
+    // Create source file
+    FILE *src_file = fopen("norm_src.txt", "w");
+    ASSUME_NOT_CNULL(src_file);
+    fprintf(src_file, "Path normalization test\n");
+    fclose(src_file);
+    
+    // Move with forward slashes (should be normalized)
+    int result = fossil_shark_move("norm_src.txt", "norm_dest.txt", false, false, false, false, false, false, cnull, cnull);
+    ASSUME_ITS_EQUAL_I32(0, result);
+    
+    // Verify move completed despite path style
+    ASSUME_ITS_TRUE(fossil_io_file_file_exists("norm_dest.txt"));
+    
+    // Clean up
+    remove("norm_dest.txt");
+}
+
 // * * * * * * * * * * * * * * * * * * * * * * * *
 // * Fossil Logic Test Pool
 // * * * * * * * * * * * * * * * * * * * * * * * *
@@ -297,6 +472,15 @@ FOSSIL_TEST_GROUP(c_move_command_tests) {
     FOSSIL_TEST_ADD(c_move_command_suite, c_test_move_special_characters);
     FOSSIL_TEST_ADD(c_move_command_suite, c_test_move_to_existing_directory);
     FOSSIL_TEST_ADD(c_move_command_suite, c_test_move_same_source_and_dest);
+    FOSSIL_TEST_ADD(c_move_command_suite, c_test_move_dry_run_no_actual_move);
+    FOSSIL_TEST_ADD(c_move_command_suite, c_test_move_with_atomic_operation);
+    FOSSIL_TEST_ADD(c_move_command_suite, c_test_move_with_progress_reporting);
+    FOSSIL_TEST_ADD(c_move_command_suite, c_test_move_with_exclude_pattern);
+    FOSSIL_TEST_ADD(c_move_command_suite, c_test_move_with_include_pattern);
+    FOSSIL_TEST_ADD(c_move_command_suite, c_test_move_with_non_matching_include_pattern);
+    FOSSIL_TEST_ADD(c_move_command_suite, c_test_move_backup_with_force);
+    FOSSIL_TEST_ADD(c_move_command_suite, c_test_move_atomic_with_progress);
+    FOSSIL_TEST_ADD(c_move_command_suite, c_test_move_path_normalization_windows_style);
 
     FOSSIL_TEST_REGISTER(c_move_command_suite);
 }


### PR DESCRIPTION
# 🛠 Pull Request

## Description
This pull request adds new flags for move and copy commands, adds safety + performance flags. --atomic (perform atomic move/copy) --checksum (verify after copy) --sparse (preserve sparse files) --link (hardlink instead of copy) --reflink (copy-on-write if supported) --progress --dry-run --exclude <pattern> --include <pattern>.

## Related Issue(s)
<!-- If this PR fixes or is related to an issue, link it here. Example: Closes #42 -->

## Changes Made
- [ ] Code cleanup
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (explain below)

## Checklist
- [ ] Code builds and passes tests
- [ ] No breaking changes introduced
- [ ] Documentation updated if necessary

## Additional Notes
<!-- Optional: Anything else reviewers should know. -->
